### PR TITLE
Add default options + stupidly fix an issue with the beautifier

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 const luamin = require('./luamin')
 
-exports.Beautify = luamin.Beautify
+exports.Beautify = (Src, Options) => {
+  const Minified = luamin.Minify(Src, Options)
+  return luamin.Beautify(Minified, Options)
+}
 exports.Minify = luamin.Minify
 exports.Uglify = luamin.Uglify

--- a/src/luamin.js
+++ b/src/luamin.js
@@ -5175,6 +5175,20 @@ function UglifyVariables(globalScope, rootScope, renameGlobals) {
     modify(rootScope)
 }
 
+// Default Options
+
+const DefaultOptions = { RenameVariables: true, RenameGlobals: false, SolveMath: true }
+
+function AddDefaultOptions(Options) {
+    Options.RenameVariables = "RenameVariables" in Options
+                                ? Options.RenameVariables : DefaultOptions.RenameVariables
+
+    Options.RenameGlobals = "RenameGlobals" in Options
+                                ? Options.RenameGlobals : DefaultOptions.RenameGlobals
+
+    Options.SolveMath = "SolveMath" in Options
+                            ? Options.SolveMath : DefaultOptions.SolveMath
+}
 
 // hi
 
@@ -5182,7 +5196,8 @@ let watermark = `--discord.gg/boronide, code generated using luamin.js™\n\n`
 
 let luaminp = {}
 
-luaminp.Minify = function(scr, options) {
+luaminp.Minify = function(scr, options = {}) {
+    AddDefaultOptions(options)
 
     let ast = CreateLuaParser(scr)
     let [glb, root] = AddVariableInfo(ast)
@@ -5203,7 +5218,9 @@ luaminp.Minify = function(scr, options) {
     return result
 }
 
-luaminp.Beautify = function(scr, options) {
+luaminp.Beautify = function(scr, options = {}) {
+    AddDefaultOptions(options)
+
     let ast = CreateLuaParser(scr)
     let [glb, root] = AddVariableInfo(ast)
     if (options.RenameVariables) {
@@ -5222,7 +5239,9 @@ luaminp.Beautify = function(scr, options) {
     return result
 }
 
-luaminp.Uglify = function(src1, options) {
+luaminp.Uglify = function(src1, options = {}) {
+    AddDefaultOptions(options)
+
     print("Sorry, but this is incredibly slow for large scripts.")
 
     let ast1 = CreateLuaParser(src1)


### PR DESCRIPTION
Added default options which are set to

- `RenameVariables`: `true`
- `RenameGlobals`: `false`
- `SolveMath`: `true`

Fixed an issue with the beautifier failing on weirdly formatted code ( fixed by minifying before beautifying )

Example input:

```lua
local function
Foo(...)
print(
...)
end

Foo(
            "Hello world!"
)
```

Output **before** change:

```lua
local function
    L_1_func(...)
        print(
...)
end

L_1_func(
            "Hello world!"
)
```

Output **after** change:

```lua
local function L_1_func(...)
        print(...)
end;
L_1_func("Hello world!")
```