### PR TITLE
Standalone else, elseif, until, etc. were correct syntax - FIXED

### DIFF
--- a/src/luamin.js
+++ b/src/luamin.js
@@ -1456,6 +1456,7 @@ function CreateLuaParser(text) {
 
 
     let blocks = 1
+    let indentation = -1
     block = function(a, b) {
         let myblocknum = blocks++
         let statements = []
@@ -1479,7 +1480,11 @@ function CreateLuaParser(text) {
 
         let thing
         let i = 0
-        while (!isLast && !isBlockFollow()) {
+        ++indentation;
+        while (peek().Type != "Eof") {
+            if (isBlockFollow() && indentation > 0) {
+                break;
+            }
             if (thing && thing == peek()) {
                 print(`INFINITE LOOP POSSIBLE ON STATEMENT ${thing.Source} :`,thing)
             }
@@ -1581,6 +1586,7 @@ function CreateLuaParser(text) {
                 }
             },
         }
+        --indentation;
         return node
     }
 


### PR DESCRIPTION
(BUG)
Repro:

1. Try to minify a single else keyword. It can be minified since it is syntactically correct. What more, anything following a single else (and other isBlockFollow keywords) is syntactically correct, since it breaks out of the main block loop.
