### PR TITLE
Last function argument was not necessary for functions - FIXED. 

### DIFF
--- a/src/luamin.js
+++ b/src/luamin.js
@@ -887,10 +887,11 @@ function CreateLuaParser(text) {
             let argNeeded = false;
             while (peek().Source != ")" || argNeeded) {
                 argList.push(expr(locals, upvals));
-                argNeeded = false;
                 if (peek().Source == ",") {
+		    argNeeded = true;
                     argCommaList.push(get())
                 } else {
+		    argNeeded = false;
                     break
                 }
             }

--- a/src/luamin.js
+++ b/src/luamin.js
@@ -884,8 +884,10 @@ function CreateLuaParser(text) {
             let oparenTk = get()
             let argList = []
             let argCommaList = []
-            while (peek().Source != ")") {
-                argList.push(expr(locals, upvals))
+            let argNeeded = false;
+            while (peek().Source != ")" || argNeeded) {
+                argList.push(expr(locals, upvals));
+                argNeeded = false;
                 if (peek().Source == ",") {
                     argCommaList.push(get())
                 } else {


### PR DESCRIPTION
(BUG)
 Any function calls having a missing last argument is syntactically correct

Repro:

1. Insert any function calls and try minifying it with the last argument missing (example: print(asd,)). This can be done, but it should be syntactically incorrect, throwing an error.